### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,23 +1,21 @@
 ## Contributing To Crossfilter
 
-### Individual Contributor License Agreement
+If you want to contribute to Crossfilter, please submit a PR with your changes. The PR should contain tests (but not build artifacts).
 
-Want to add support for a new backend or visualization? We'd love for you to participate in the development of Crossfilter. Before we can accept your pull request, please sign our [Individual Contributor License Agreement][1]. It's a short form that covers our bases and makes sure you're eligible to contribute. Thank you!
-
-  [1]: https://spreadsheets.google.com/spreadsheet/viewform?formkey=dDViT2xzUHAwRkI3X3k5Z0lQM091OGc6MQ&ndplr=1
+This is a community-maintained fork of [square/crossfilter](https://github.com/square/crossfilter) and you don't need to sign a contributor agreement.
 
 ### Getting Help
 
-Full API documentation is kept [in the wiki][2]. If you have a question or need help using Crossfilter, please ask on Stackoverflow using the [crossfilter tag][3]. Feel free to file bug reports and other suggestions in the [github issue tracker][4]. 
+Full API documentation is kept [in the wiki][2]. If you have a question or need help using Crossfilter, please ask on Stackoverflow using the [crossfilter tag][3], or on the [crossfilter users group](https://groups.google.com/forum/#!forum/crossfilter). Feel free to file bug reports and other suggestions in the [github issue tracker][4].
 
   [2]: https://github.com/square/crossfilter/wiki
   [3]: http://stackoverflow.com/questions/tagged/crossfilter
-  [4]: https://github.com/square/crossfilter/issues
+  [4]: https://github.com/crossfilter/crossfilter/issues
 
 ### License
 
 Crossfilter is available under the [Apache License][5].
 
-  [5]: https://github.com/square/crossfilter/blob/master/LICENSE
+  [5]: https://github.com/crossfilter/crossfilter/blob/master/LICENSE
 
 


### PR DESCRIPTION
Simple change to note that this is a community-maintained fork and no contributor agreement is necessary. Adds link to new google group.

Does not fix #2 wiki documentation, so still keeping the link back to square/crossfilter for documentation.