### PR TITLE
Limit packaging extraneous files

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,0 @@
-test/
-lib/
-.DS_Store

--- a/package.json
+++ b/package.json
@@ -42,5 +42,9 @@
   },
   "scripts": {
     "test": "./node_modules/.bin/vows"
-  }
+  },
+  "files": [
+    "src",
+    "index.js"
+  ]
 }


### PR DESCRIPTION
Currently crossfilter publishes the following files/folders to NPM. This is already pretty good, but we can do better!

```
   84.0 KiB [##########] /src                                                                                                  
   44.0 KiB [#####     ]  crossfilter.js
   12.0 KiB [#         ]  crossfilter.min.js
    4.0 KiB [          ]  package.json
    4.0 KiB [          ]  CONTRIBUTING.md
    4.0 KiB [          ]  README.md
    4.0 KiB [          ]  Makefile
    4.0 KiB [          ]  LICENSE
    4.0 KiB [          ]  component.json
    4.0 KiB [          ]  index.js
    4.0 KiB [          ]  .travis.yml
    4.0 KiB [          ]  .npmignore
```

This PR removes things like `CONTRIBUTING.md` and `.travis.yml`.
`package.json`, the `README`, and the `LICENSE` are automatically retained by NPM.

https://docs.npmjs.com/files/package.json#files