### PR TITLE
Use browserify transform to only include package.json's 'version' field

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "scripts": {
     "benchmark": "node test/benchmark.js",
-    "build": "browserify index.js --standalone crossfilter -o crossfilter.js && uglifyjs --screw-ie8 crossfilter.js -o crossfilter.min.js",
+    "build": "browserify index.js -t package-json-versionify --standalone crossfilter -o crossfilter.js && uglifyjs --screw-ie8 crossfilter.js -o crossfilter.min.js",
     "clean": "rm -f crossfilter.js crossfilter.min.js",
     "test": "./node_modules/.bin/vows --verbose"
   },

--- a/src/crossfilter.js
+++ b/src/crossfilter.js
@@ -20,7 +20,7 @@ exports.crossfilter.bisect = bisect;
 exports.crossfilter.insertionsort = insertionsort;
 exports.crossfilter.permute = permute;
 exports.crossfilter.quicksort = quicksort;
-exports.crossfilter.version = packageJson.version;
+exports.crossfilter.version = packageJson.version; // please note use of "package-json-versionify" transform
 
 function crossfilter() {
   var crossfilter = {


### PR DESCRIPTION
This utilizes the `package-json-versionify` browserify transform I included in the original build overhaul PR and forgot to actually use. The overall effect of this is a reduced `crossfilter.js` and `crossfilter.min.js` build size (about 57 lines removed).

Risk of breakage to crossfilter is (or should be) 0 since the only use of package.json in crossfilter is of the version field.