### PR TITLE
Include source files in npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "test": "./node_modules/.bin/vows --verbose"
   },
   "files": [
+    "src",
     "index.js",
     "crossfilter.js",
     "crossfilter.min.js"


### PR DESCRIPTION
I made a mistake in PR #48 where I excluded the `src` folder from being uploaded to npm. I should have included the files because webpack and jspm bundle the source files directly instead of using the prebuilt files. Package managers like bower should and will need to reference the built `crossfilter.js` and `crossfilter.min.js` files. My apologies for the mixup.

Here is the output I get from webpack today using crossfilter2@1.4.0-alpha.2:
```
ERROR in ./~/crossfilter2/index.js
Module not found: Error: Cannot resolve 'file' or 'directory' ./src/crossfilter in /Users/Mark/projects/badgeup-dashboard/node_modules/crossfilter2
 @ ./~/crossfilter2/index.js 1:17-45
```

Ping @esjewett 