### PR TITLE
feat: Adds string shorthand for creating dimension accessors

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,9 @@
     "type": "git",
     "url": "http://github.com/crossfilter/crossfilter.git"
   },
+  "dependencies": {
+    "lodash.result": "^4.4.0"
+  },
   "devDependencies": {
     "browserify": "^13.0.0",
     "d3": "3.5",

--- a/src/crossfilter.js
+++ b/src/crossfilter.js
@@ -11,7 +11,7 @@ var permute = require('./permute');
 var quicksort = require('./quicksort');
 var xfilterReduce = require('./reduce');
 var packageJson = require('./../package.json'); // require own package.json for the version field
-
+var result = require('lodash.result');
 // expose API exports
 exports.crossfilter = crossfilter;
 exports.crossfilter.heap = xfilterHeap;
@@ -113,6 +113,12 @@ function crossfilter() {
 
   // Adds a new dimension with the specified value accessor function.
   function dimension(value, iterable) {
+
+    if (typeof value === 'string') {
+      var accessorPath = value;
+      value = function(d) { return result(d, accessorPath); };
+    }
+
     var dimension = {
       filter: filter,
       filterExact: filterExact,

--- a/test/crossfilter-test.js
+++ b/test/crossfilter-test.js
@@ -63,7 +63,11 @@ suite.addBatch({
         data.tip = data.dimension(function(d) { return d.tip; });
         data.total = data.dimension(function(d) { return d.total; });
         data.type = data.dimension(function(d) { return d.type; });
+        data.typeByString = data.dimension('type');
         data.tags = data.dimension(function(d) { return d.tags; }, true);
+        data.firstTag = data.dimension('tags[0]');
+        data.year = data.dimension('getYear');
+
       } catch (e) {
         console.log(e.stack);
       }
@@ -275,9 +279,25 @@ suite.addBatch({
     },
 
     "dimension": {
-      
+
       "accessor": function(data) {
         assert.equal(data.type.accessor({ type: "a type" }), "a type");
+      },
+
+      "stringAccessor": function(data) {
+        assert.equal(data.typeByString.accessor({ type: "a type" }), "a type");
+      },
+
+      "stringPathAccessor": function(data) {
+        assert.equal(data.firstTag.accessor({ tags: [2,4,5] }), 2);
+        assert.equal(data.firstTag.accessor({ tags: [4,5] }), 4);
+      },
+
+      "stringFunctionCallAccessor": function(data) {
+        function getYear() {
+          return new Date(this.date).getFullYear();
+        }
+        assert.equal(data.year.accessor({date: "2011-11-14T16:28:54Z", getYear: getYear }), 2011);
       },
 
       "top": {
@@ -297,7 +317,7 @@ suite.addBatch({
           assert.deepEqual(data.total.top(3, 1), [
             {date: "2011-11-14T20:49:07Z", quantity: 2, total: 290, tip: 200, type: "tab", tags: [2,4,5]},
             {date: "2011-11-14T21:18:48Z", quantity: 4, total: 270, tip: 0, type: "tab", tags: [1,2,3]},
-            {date: "2011-11-14T17:38:40Z", quantity: 2, total: 200, tip: 100, type: 'visa', tags: [2,4,5]} 
+            {date: "2011-11-14T17:38:40Z", quantity: 2, total: 200, tip: 100, type: 'visa', tags: [2,4,5]}
           ]);
           assert.deepEqual(data.date.top(3,10), [
             {date: "2011-11-14T22:30:22Z", quantity: 2, total: 89, tip: 0, type: "tab", tags: [1,3]},
@@ -345,7 +365,7 @@ suite.addBatch({
               {date: "2011-11-14T21:18:48Z", quantity: 4, total: 270, tip: 0, type: "tab", tags: [1,2,3]}
             ]);
             assert.deepEqual(data.total.top(2, 8), [
-              {date: '2011-11-14T21:26:30Z', quantity: 2, total: 190, tip: 100, type: 'tab', tags: [2,4,5]}, 
+              {date: '2011-11-14T21:26:30Z', quantity: 2, total: 190, tip: 100, type: 'tab', tags: [2,4,5]},
               {date: '2011-11-14T23:28:54Z', quantity: 2, total: 190, tip: 100, type: 'tab', tags: [1,2,3]}
             ]);
             data.type.filterExact("visa");
@@ -367,7 +387,7 @@ suite.addBatch({
               {date: "2011-11-14T23:23:29Z", quantity: 2, total: 190, tip: 100, type: "tab", tags: [2,3,4]}
             ]);
             assert.deepEqual(data.date.top(2, 8), [
-              {date: '2011-11-14T22:30:22Z', quantity: 2, total: 89, tip: 0, type: 'tab', tags: [1,3]}, 
+              {date: '2011-11-14T22:30:22Z', quantity: 2, total: 89, tip: 0, type: 'tab', tags: [1,3]},
               {date: '2011-11-14T21:31:05Z', quantity: 2, total: 90, tip: 0, type: 'tab', tags: [1,2,3]}
             ]);
             data.type.filterExact("visa");
@@ -466,7 +486,7 @@ suite.addBatch({
             ]);
             data.type.filterExact("tab");
             assert.deepEqual(data.total.bottom(2, 8), [
-              {date: '2011-11-14T17:52:02Z', quantity: 2, total: 90, tip: 0, type: 'tab', tags: [2,3,4]}, 
+              {date: '2011-11-14T17:52:02Z', quantity: 2, total: 90, tip: 0, type: 'tab', tags: [2,3,4]},
               {date: '2011-11-14T18:45:24Z', quantity: 2, total: 90, tip: 0, type: 'tab', tags: [2,4,5]}
             ]);
             data.type.filterExact("visa");
@@ -488,7 +508,7 @@ suite.addBatch({
               {date: "2011-11-14T16:20:19Z", quantity: 2, total: 190, tip: 100, type: "tab", tags: [1,3]}
             ]);
             assert.deepEqual(data.date.bottom(2, 8), [
-              {date: '2011-11-14T17:33:46Z', quantity: 2, total: 190, tip: 100, type: 'tab', tags: [1,2,3]}, 
+              {date: '2011-11-14T17:33:46Z', quantity: 2, total: 190, tip: 100, type: 'tab', tags: [1,2,3]},
               {date: '2011-11-14T17:33:59Z', quantity: 2, total: 90, tip: 0, type: 'tab', tags: [1,3]}
             ]);
             data.type.filterExact("visa");
@@ -2104,7 +2124,7 @@ suite.addBatch({
             }
           }
         },
-        
+
         "works for empty arrays in middle or end": function() {
           var data = crossfilter([
               {tags: [1,2,3]},
@@ -2158,7 +2178,7 @@ suite.addBatch({
         },
       },
     },
-      
+
     "isElementFiltered": {
       "Test if elements are filtered": function(data) {
         try {
@@ -2206,9 +2226,9 @@ suite.addBatch({
           data.quantity.filterAll();
           data.total.filterAll();
         }
-      },        
+      },
     },
-      
+
   }
 });
 


### PR DESCRIPTION
This PR introduces the ability to use a string based shorthand when creating dimension accessors, see examples below.
* Includes test coverage
* All existing tests pass

I use this enhancement to reduce boilerplate and help crossfilter/dc.js projects maintain readability. Since this could be of use to others I figured I would suggest it upstream.

##### Example 1:
A simple property name
```js
data.dimension(function(d) { return d.type; });
```
Can now be [expressed as](#diff-651f62a9bb8f6bd367f8fe5af63791baR66):
```js
data.dimension('type');
```


##### Example 2, array expression:
Accessing an array value
```js
data.dimension(function(d) { return d.tags[0]; });
```

Can now be [expressed as](#diff-651f62a9bb8f6bd367f8fe5af63791baR68)
```js
data.dimension('tags[0]');
```

##### Example 3, nested path expression:
Accessing a value on an object within an array (any level/combination of nesting will work).
```js
data.dimension(function(d) { 
  if (d.addresses !== undefined && d.addresses[0] !== undefined) {
    return d.address[0].zipCode;
  }
});
```

Can now be expressed as:
```js
data.dimension('addresses[0].zipCode');
```


##### Example 4, function path expressions:
If the path returns a function, automatically invoke it
```js
data.dimension(function(d) { return d.getYear(); });
```

Can now be [expressed as](#diff-651f62a9bb8f6bd367f8fe5af63791baR296):
```js
data.dimension('getYear');
```