### PR TITLE
Reduce minified bundle size by ~50%

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "scripts": {
     "benchmark": "node test/benchmark.js",
-    "build": "browserify index.js -t package-json-versionify --standalone crossfilter -o crossfilter.js && uglifyjs --screw-ie8 crossfilter.js -o crossfilter.min.js",
+    "build": "browserify index.js -t package-json-versionify --standalone crossfilter -o crossfilter.js && uglifyjs --compress --mangle --screw-ie8 crossfilter.js -o crossfilter.min.js",
     "clean": "rm -f crossfilter.js crossfilter.min.js",
     "test": "./node_modules/.bin/vows --verbose"
   },


### PR DESCRIPTION
This PR reduces the size of `crossfilter.min.js` from [~31kb](https://github.com/crossfilter/crossfilter/blob/master/crossfilter.min.js) to [~17kb](https://github.com/TomNeyland/crossfilter-1/blob/bundle-optimization-artifacts/crossfilter.min.js) by enabling [uglify's compressor](https://github.com/mishoo/UglifyJS2/blob/master/README.md#compressor-options) and [mangler](https://github.com/mishoo/UglifyJS2/blob/master/README.md#mangler-options)

* Updates the uglify options
* Does not commit an updated build
