### PR TITLE
Fixed array dimensions empty row tracking and filter status tracking.

### DIFF
--- a/src/crossfilter.js
+++ b/src/crossfilter.js
@@ -151,7 +151,7 @@ function crossfilter() {
         newIterablesIndexCount,
         iterablesIndexFilterStatus,
         newIterablesIndexFilterStatus,
-        iterablesEmptyRows,
+        iterablesEmptyRows = [],
         sort = quicksort.by(function(i) { return newValues[i]; }),
         refilter = xfilterFilter.filterAll, // for recomputing filter
         refilterFunction, // the custom filter function in use
@@ -204,7 +204,6 @@ function crossfilter() {
         newValues = [];
         newIterablesIndexCount = crossfilter_range(newData.length);
         newIterablesIndexFilterStatus = crossfilter_index(t,1);
-        iterablesEmptyRows = [];
         var unsortedIndex = crossfilter_range(t);
 
         for (var l = 0, index1 = 0; index1 < newData.length; index1++) {
@@ -212,7 +211,7 @@ function crossfilter() {
           //
           if(!k.length){
             newIterablesIndexCount[index1] = 0;
-            iterablesEmptyRows.push(index1);
+            iterablesEmptyRows.push(index1 + n0);
             continue;
           }
           newIterablesIndexCount[index1] = k.length
@@ -316,7 +315,7 @@ function crossfilter() {
           index[index5] = oldIndex[i0++];
         } else {
           values[index5] = newValues[i1];
-          if(iterable) iterablesIndexFilterStatus[index5] = oldIterablesIndexFilterStatus[i1];
+          if(iterable) iterablesIndexFilterStatus[index5] = newIterablesIndexFilterStatus[i1];
           index[index5] = newIndex[i1++] + (iterable ? old_n0 : n0);
         }
       }
@@ -331,7 +330,7 @@ function crossfilter() {
       // Add any remaining new values.
       for (; i1 < n1; ++i1, ++index5) {
         values[index5] = newValues[i1];
-        if(iterable) iterablesIndexFilterStatus[index5] = oldIterablesIndexFilterStatus[i1];
+        if(iterable) iterablesIndexFilterStatus[index5] = newIterablesIndexFilterStatus[i1];
         index[index5] = newIndex[i1] + (iterable ? old_n0 : n0);
       }
 


### PR DESCRIPTION
Found an issue with the way empty rows and filter status were being tracked with array dimensions. IterablesEmptyRows was being overwritten every time data was added and oldIterablesIndexFilterStatus was incorrectly being used when setting new values.