### PR TITLE
Fixed issue with disposing groupAll groups.

### DIFF
--- a/src/crossfilter.js
+++ b/src/crossfilter.js
@@ -1309,9 +1309,9 @@ function crossfilter() {
     // Removes this group and associated event listeners.
     function dispose() {
       var i = filterListeners.indexOf(update);
-      if (i >= 0) filterListeners.splice(i);
+      if (i >= 0) filterListeners.splice(i, 1);
       i = dataListeners.indexOf(add);
-      if (i >= 0) dataListeners.splice(i);
+      if (i >= 0) dataListeners.splice(i, 1);
       return group;
     }
 

--- a/test/crossfilter-test.js
+++ b/test/crossfilter-test.js
@@ -1218,6 +1218,29 @@ suite.addBatch({
           all.dispose();
           data.add([3, 4, 5]);
           assert.isFalse(callback);
+        },
+        "does not detach other reduce listeners": function() {
+          var data = crossfilter([0, 1, 2]),
+              callback, // indicates a reduce has occurred in this group
+              other = data.dimension(function(d) { return d; }),
+              all = data.groupAll(),
+              all2 = data.groupAll().reduce(function() { callback = true; }, function() { callback = true; }, function() {});
+          all2.value(); // force this group to be reduced when filters change
+          callback = false;
+          all.dispose();
+          other.filterRange([1, 2]);
+          assert.isTrue(callback);
+        },
+        "does not detach other add listeners": function() {
+          var data = crossfilter([0, 1, 2]),
+              callback, // indicates data has been added and triggered a reduce
+              all = data.groupAll(),
+              all2 = data.groupAll().reduce(function() { callback = true; }, function() { callback = true; }, function() {});
+          all2.value(); // force this group to be reduced when data is added
+          callback = false;
+          all.dispose();
+          data.add([3, 4, 5]);
+          assert.isTrue(callback);
         }
       }
     },


### PR DESCRIPTION
Found an issue with disposing groupAll groups. Disposing a groupAll group removed all filter and data listeners that came after its own listeners.