### PR TITLE
Fixed issues with removing data from iterable dimensions and groups.

### DIFF
--- a/src/crossfilter.js
+++ b/src/crossfilter.js
@@ -790,7 +790,7 @@ function crossfilter() {
         // Also, make sure that groupIndex exists and is long enough.
         groups = new Array(k), k = 0;
         if(iterable){
-          groupIndex = k0 > 1 ? groupIndex : [];
+          groupIndex = k0 ? groupIndex : [];
         }
         else{
           groupIndex = k0 > 1 ? xfilterArray.arrayLengthen(groupIndex, n) : crossfilter_index(n, groupCapacity);
@@ -895,7 +895,7 @@ function crossfilter() {
         // and therefore no groups to update or reset. Note that we also must
         // change the registered listener to point to the new method.
         j = filterListeners.indexOf(update);
-        if (k > 1) {
+        if (k > 1 || iterable) {
           update = updateMany;
           reset = resetMany;
         } else {

--- a/src/crossfilter.js
+++ b/src/crossfilter.js
@@ -345,15 +345,32 @@ function crossfilter() {
     }
 
     function removeData(reIndex) {
-      for (var i = 0, j = 0, k; i < n; ++i) {
+      if (iterable) {
+        for (var i0 = 0, i1 = 0; i0 < iterablesEmptyRows.length; i0++) {
+          if (!filters.zero(iterablesEmptyRows[i0])) {
+            iterablesEmptyRows[i1] = reIndex[iterablesEmptyRows[i0]];
+            i1++;
+          }
+        }
+        iterablesEmptyRows.length = i1;
+        for (i0 = 0, i1 = 0; i0 < n; i0++) {
+          if (!filters.zero(i0)) {
+            iterablesIndexCount[reIndex[i0]] = iterablesIndexCount[i0];
+            i1++;
+          }
+        }
+        iterablesIndexCount.length = i1;
+      }
+      for (var i = 0, j = 0, k, n0 = values.length; i < n0; ++i) {
         if (!filters.zero(k = index[i])) {
           if (i !== j) values[j] = values[i];
           index[j] = reIndex[k];
+          if (iterable) iterablesIndexFilterStatus[j] = iterablesIndexFilterStatus[i];
           ++j;
         }
       }
       values.length = j;
-      while (j < n) index[j++] = 0;
+      while (j < n0) index[j++] = 0;
 
       // Bisect again to recompute lo0 and hi0.
       var bounds = refilter(values);
@@ -510,7 +527,7 @@ function crossfilter() {
       refilter = xfilterFilter.filterAll;
 
       filterIndexFunction(f, false);
-
+      
       lo0 = 0;
       hi0 = n;
 
@@ -913,17 +930,32 @@ function crossfilter() {
       }
 
       function removeData() {
-        if (k > 1) {
+        if (k > 1 || iterable) {
           var oldK = k,
               oldGroups = groups,
-              seenGroups = crossfilter_index(oldK, oldK);
+              seenGroups = crossfilter_index(oldK, oldK),
+              i,
+              i0,
+              j;
 
           // Filter out non-matches by copying matching group index entries to
           // the beginning of the array.
-          for (var i = 0, j = 0; i < n; ++i) {
-            if (!filters.zero(i)) {
-              seenGroups[groupIndex[j] = groupIndex[i]] = 1;
-              ++j;
+          if (!iterable) {
+            for (i = 0, j = 0; i < n; ++i) {
+              if (!filters.zero(i)) {
+                seenGroups[groupIndex[j] = groupIndex[i]] = 1;
+                ++j;
+              }
+            }
+          } else {
+            for (i = 0, j = 0; i < n; ++i) {
+              if (!filters.zero(i)) {
+                groupIndex[j] = groupIndex[i];
+                for (i0 = 0; i0 < groupIndex[j].length; i0++) {
+                  seenGroups[groupIndex[j][i0]] = 1;
+                }
+                ++j;
+              }
             }
           }
 
@@ -938,13 +970,21 @@ function crossfilter() {
             }
           }
 
-          if (k > 1) {
+          if (k > 1 || iterable) {
             // Reindex the group index using seenGroups to find the new index.
-            for (var index2 = 0; index2 < j; ++index2) groupIndex[index2] = seenGroups[groupIndex[index2]];
+            if (!iterable) {
+              for (i = 0; i < j; ++i) groupIndex[i] = seenGroups[groupIndex[i]];
+            } else {
+              for (i = 0; i < j; ++i) {
+                for (i0 = 0; i0 < groupIndex[i].length; ++i0) {
+                  groupIndex[i][i0] = seenGroups[groupIndex[i][i0]];
+                }
+              }
+            }
           } else {
             groupIndex = null;
           }
-          filterListeners[filterListeners.indexOf(update)] = k > 1
+          filterListeners[filterListeners.indexOf(update)] = k > 1 || iterable
               ? (reset = resetMany, update = updateMany)
               : k === 1 ? (reset = resetOne, update = updateOne)
               : reset = update = crossfilter_null;

--- a/src/crossfilter.js
+++ b/src/crossfilter.js
@@ -386,7 +386,7 @@ function crossfilter() {
 
       if (refilterFunction) {
         refilterFunction = null;
-        filterIndexFunction(function(d, i) { return lo1 <= i && i < hi1; }, bounds[0] === 0 && bounds[1] === index.length);
+        filterIndexFunction(function(d, i) { return lo1 <= i && i < hi1; }, bounds[0] === 0 && bounds[1] === values.length);
         lo0 = lo1;
         hi0 = hi1;
         return dimension;
@@ -466,7 +466,7 @@ function crossfilter() {
         removed = newRemoved;
 
         // Now handle empty rows.
-        if(bounds[0] === 0 && bounds[1] === index.length) {
+        if(bounds[0] === 0 && bounds[1] === values.length) {
           for(i = 0; i < iterablesEmptyRows.length; i++) {
             if((filters[offset][k = iterablesEmptyRows[i]] & one)) {
               // Was not in the filter, so set the filter and add
@@ -528,8 +528,8 @@ function crossfilter() {
 
       filterIndexFunction(f, false);
       
-      lo0 = 0;
-      hi0 = n;
+      var bounds = refilter(values);
+      lo0 = bounds[0], hi0 = bounds[1];
 
       return dimension;
     }
@@ -542,7 +542,7 @@ function crossfilter() {
           removed = [],
           valueIndexAdded = [],
           valueIndexRemoved = [],
-          indexLength = index.length;
+          indexLength = values.length;
 
       if(!iterable) {
         for (i = 0; i < indexLength; ++i) {

--- a/test/crossfilter-test.js
+++ b/test/crossfilter-test.js
@@ -1815,7 +1815,7 @@ suite.addBatch({
             var group = data.tags.groupAll().reduceCount();
             data.total.filterRange([200, Infinity]);
             data.total.filterFunction(function(d) { return "0"; });
-            assert.equal(group.value(), 43);
+            assert.equal(group.value(), 119);
             data.total.filterFunction(function(d) { return ""; });
             assert.equal(group.value(), 0);
           } finally {
@@ -1826,9 +1826,9 @@ suite.addBatch({
           try {
             var group = data.tags.groupAll().reduceCount();
             data.total.filterFunction(function(d) { return d === 90; });
-            assert.equal(group.value(), 13);
+            assert.equal(group.value(), 33);
             data.total.filterFunction(function(d) { return d === 91; });
-            assert.equal(group.value(), 1);
+            assert.equal(group.value(), 3);
           } finally {
             data.total.filterAll();
           }
@@ -2114,10 +2114,18 @@ suite.addBatch({
               data.val.filter(2);
               data.remove();
               assert.deepEqual(data.val.groupSumLength.all(), [
-                { key: 6, value: 4 }
+                { key: 3, value: 3 },
+                { key: 4, value: 3 },
+                { key: 5, value: 6 },
+                { key: 6, value: 4 },
+                { key: 7, value: 3 }
               ]);
               assert.deepEqual(data.val.groupSumEach.all(), [
-                { key: 6, value: 4 }
+                { key: 3, value: 3 },
+                { key: 4, value: 3 },
+                { key: 5, value: 6 },
+                { key: 6, value: 4 },
+                { key: 7, value: 3 }
               ]);
 
               data.val.filterAll();

--- a/test/crossfilter-test.js
+++ b/test/crossfilter-test.js
@@ -2401,10 +2401,455 @@ suite.addBatch({
           } finally {
             data.quantity.filterAll();
           }
+        },
+        "one tag with one empty": function() {
+          var set = [
+            {name: "alpha", quantity: 2, tags: [1]},
+            {name: "bravo", quantity: 1, tags: []}
+          ];
+          var data = crossfilter();
+          data.tags = data.dimension(function(d) { return d.tags; }, true);
+          data.tagGroup = data.tags.group();
+          data.add(set);
+          assert.deepEqual(data.tagGroup.all(), [
+            {key: 1, value: 1}
+          ]);
+        },
+        "one tag then add empty": function() {
+          var firstSet = [
+            {name: "alpha", quantity: 2, tags: [1]}
+          ];
+          var secondSet = [
+            {name: "bravo", quantity: 1, tags: []}
+          ];
+          var data = crossfilter();
+          data.tags = data.dimension(function(d) { return d.tags; }, true);
+          data.quantity = data.dimension(function(d) {return d.quantity; });
+          data.tagGroup = data.tags.group();
+          data.add(firstSet);
+          data.add(secondSet);
+          assert.deepEqual(data.tagGroup.all(), [
+            {key: 1, value: 1}
+          ]);
+        },
+        "empty tag then add one tag": function() {
+          var firstSet = [
+            {name: "alpha", quantity: 2, tags: []}
+          ];
+          var secondSet = [
+            {name: "bravo", quantity: 1, tags: [1]}
+          ];
+          var data = crossfilter();
+          data.tags = data.dimension(function(d) { return d.tags; }, true);
+          data.quantity = data.dimension(function(d) {return d.quantity; });
+          data.tagGroup = data.tags.group();
+          data.add(firstSet);
+          data.add(secondSet);
+          assert.deepEqual(data.tagGroup.all(), [
+            {key: 1, value: 1}
+          ]);
+        },
+        "one tag then add one more tag": function() {
+          var firstSet = [
+            {name: "alpha", quantity: 2, tags: [1]}
+          ];
+          var secondSet = [
+            {name: "bravo", quantity: 1, tags: [2]}
+          ];
+          var data = crossfilter();
+          data.tags = data.dimension(function(d) { return d.tags; }, true);
+          data.quantity = data.dimension(function(d) {return d.quantity; });
+          data.tagGroup = data.tags.group();
+          data.add(firstSet);
+          data.add(secondSet);
+          assert.deepEqual(data.tagGroup.all(), [
+            {key: 1, value: 1},
+            {key: 2, value: 1}
+          ]);
         }
       }
     },
-
+    "iterable remove" : {
+      "dimension": {
+        "other dimension filtered remove": function() {
+          var set = [
+            {name: "alpha", quantity: 1, tags: [1, 3]},
+            {name: "bravo", quantity: 0, tags: [1, 3]},
+            {name: "charlie", quantity: 3, tags: [2]},
+            {name: "delta", quantity: 3, tags: [2, 3]},
+            {name: "echo", quantity: 2, tags: [4]},
+            {name: "foxtrot", quantity: 1, tags: []}
+          ];
+          var data = crossfilter();
+          data.tags = data.dimension(function(d) { return d.tags; }, true);
+          data.quantity = data.dimension(function(d) {return d.quantity; });
+          data.add(set);
+          data.quantity.filterExact(3);
+          data.remove();
+          data.quantity.filterAll();
+          var top = data.tags.top(7);
+          assert.equal(top.length, 6);
+          assert.equal(Math.max.apply(null, top[0].tags), 4);
+          assert.equal(Math.max.apply(null, top[1].tags), 3);
+          assert.equal(Math.min.apply(null, top[1].tags), 1);
+          assert.equal(Math.max.apply(null, top[2].tags), 3);
+          assert.equal(Math.min.apply(null, top[2].tags), 1);
+          assert.equal(Math.max.apply(null, top[3].tags), 3);
+          assert.equal(Math.min.apply(null, top[3].tags), 1);
+          assert.equal(Math.max.apply(null, top[4].tags), 3);
+          assert.equal(Math.min.apply(null, top[4].tags), 1);
+          assert.equal(top[5].tags.length, 0);
+        },
+        "self filterExact remove": function() {
+          var set = [
+            {name: "alpha", quantity: 1, tags: [1, 3]},
+            {name: "bravo", quantity: 0, tags: [1, 3]},
+            {name: "charlie", quantity: 3, tags: [2]},
+            {name: "delta", quantity: 3, tags: [2, 3]},
+            {name: "echo", quantity: 2, tags: [4]},
+            {name: "foxtrot", quantity: 1, tags: []}
+          ];
+          var data = crossfilter();
+          data.tags = data.dimension(function(d) { return d.tags; }, true);
+          data.add(set);
+          data.tags.filterExact(2);
+          data.remove();
+          data.tags.filterAll();
+          var top = data.tags.top(7);
+          assert.equal(top.length, 6);
+          assert.equal(Math.max.apply(null, top[0].tags), 4);
+          assert.equal(Math.max.apply(null, top[1].tags), 3);
+          assert.equal(Math.min.apply(null, top[1].tags), 1);
+          assert.equal(Math.max.apply(null, top[2].tags), 3);
+          assert.equal(Math.min.apply(null, top[2].tags), 1);
+          assert.equal(Math.max.apply(null, top[3].tags), 3);
+          assert.equal(Math.min.apply(null, top[3].tags), 1);
+          assert.equal(Math.max.apply(null, top[4].tags), 3);
+          assert.equal(Math.min.apply(null, top[4].tags), 1);
+          assert.equal(top[5].tags.length, 0);
+        },
+        "self filterFunction remove": function() {
+          var set = [
+            {name: "alpha", quantity: 1, tags: [1, 3]},
+            {name: "bravo", quantity: 0, tags: [1, 3]},
+            {name: "charlie", quantity: 3, tags: [2]},
+            {name: "delta", quantity: 3, tags: [2, 3]},
+            {name: "echo", quantity: 2, tags: [4]},
+            {name: "foxtrot", quantity: 1, tags: []}
+          ];
+          var data = crossfilter();
+          data.tags = data.dimension(function(d) { return d.tags; }, true);
+          data.add(set);
+          data.tags.filterFunction(function(d) { return d === 2; });
+          data.remove();
+          data.tags.filterAll();
+          var top = data.tags.top(7);
+          assert.equal(top.length, 6);
+          assert.equal(Math.max.apply(null, top[0].tags), 4);
+          assert.equal(Math.max.apply(null, top[1].tags), 3);
+          assert.equal(Math.min.apply(null, top[1].tags), 1);
+          assert.equal(Math.max.apply(null, top[2].tags), 3);
+          assert.equal(Math.min.apply(null, top[2].tags), 1);
+          assert.equal(Math.max.apply(null, top[3].tags), 3);
+          assert.equal(Math.min.apply(null, top[3].tags), 1);
+          assert.equal(Math.max.apply(null, top[4].tags), 3);
+          assert.equal(Math.min.apply(null, top[4].tags), 1);
+          assert.equal(top[5].tags.length, 0);
+        },
+        "other dimension filtered then self filterFunction remove": function() {
+          var set = [
+            {name: "alpha", quantity: 1, tags: [1, 3]},
+            {name: "bravo", quantity: 0, tags: [1, 3]},
+            {name: "charlie", quantity: 3, tags: [2]},
+            {name: "delta", quantity: 3, tags: [2, 3]},
+            {name: "echo", quantity: 2, tags: [4]},
+            {name: "foxtrot", quantity: 1, tags: []}
+          ];
+          var data = crossfilter();
+          data.tags = data.dimension(function(d) { return d.tags; }, true);
+          data.quantity = data.dimension(function(d) { return d.quantity; });
+          data.add(set);
+          data.quantity.filterExact(3);
+          data.remove();
+          data.quantity.filterAll();
+          data.tags.filterFunction(function(d) { return d === 1; });
+          data.remove();
+          data.tags.filterAll();
+          assert.deepEqual(data.tags.top(3), [
+            {name: "echo", quantity: 2, tags: [4]},
+            {name: "foxtrot", quantity: 1, tags: []}
+          ]);
+        },
+        "remove then add": function() {
+          var firstSet = [
+            {name: "alpha", quantity: 1, tags: [1, 3]},
+            {name: "bravo", quantity: 0, tags: [1, 3]},
+            {name: "charlie", quantity: 3, tags: [2]},
+            {name: "delta", quantity: 3, tags: [2, 3]},
+            {name: "echo", quantity: 2, tags: [4]},
+            {name: "foxtrot", quantity: 1, tags: []}
+          ];
+          var secondSet = [
+            {name: "golf", quantity: 3, tags: [1]}
+          ];
+          var data = crossfilter();
+          data.tags = data.dimension(function(d) { return d.tags; }, true);
+          data.quantity = data.dimension(function(d) { return d.quantity; });
+          data.add(firstSet);
+          data.quantity.filterExact(3);
+          data.remove();
+          data.quantity.filterAll();
+          data.tags.filterFunction(function(d) { return d === 1; });
+          data.remove();
+          data.tags.filterAll();
+          data.add(secondSet);
+          assert.deepEqual(data.tags.top(3), [
+            {name: "echo", quantity: 2, tags: [4]},
+            {name: "golf", quantity: 3, tags: [1]},
+            {name: "foxtrot", quantity: 1, tags: []}
+          ]);
+        },
+        "filter then remove empty tag to only one tag": function() {
+          var set = [
+            {name: "alpha", quantity: 2, tags: [1]},
+            {name: "bravo", quantity: 1, tags: []}
+          ];
+          var data = crossfilter();
+          data.tags = data.dimension(function(d) { return d.tags; }, true);
+          data.quantity = data.dimension(function(d) {return d.quantity; });
+          data.add(set);
+          data.quantity.filterExact(1);
+          data.remove();
+          data.quantity.filterAll();
+          assert.deepEqual(data.tags.top(2), [
+            {name: "alpha", quantity: 2, tags: [1]}
+          ]);
+        },
+        "filter remove one tag to only empty tag": function() {
+          var set = [
+            {name: "alpha", quantity: 2, tags: [1]},
+            {name: "bravo", quantity: 1, tags: []}
+          ];
+          var data = crossfilter();
+          data.tags = data.dimension(function(d) { return d.tags; }, true);
+          data.quantity = data.dimension(function(d) {return d.quantity; });
+          data.add(set);
+          data.quantity.filterExact(2);
+          data.remove();
+          data.quantity.filterAll();
+          assert.deepEqual(data.tags.top(2), [
+            {name: "bravo", quantity: 1, tags: []}
+          ]);
+        },
+        "remove multiple tag, add single tag, others observer filter": function() {
+          var firstSet = [
+            {name: "alpha", quantity: 2, tags: [1]},
+            {name: "bravo", quantity: 1, tags: [2, 3]}
+          ];
+          var secondSet = [
+            {name: "charlie", quantity: 3, tags: [4]}
+          ];
+          var data = crossfilter();
+          data.tags = data.dimension(function(d) { return d.tags; }, true);
+          data.quantity = data.dimension(function(d) {return d.quantity; });
+          data.add(firstSet);
+          data.quantity.filterExact(1);
+          data.remove();
+          data.quantity.filterAll();
+          data.add(secondSet);
+          data.tags.filterExact(1);
+          assert.deepEqual(data.quantity.top(2), [
+            {name: "alpha", quantity: 2, tags: [1]},
+          ]);
+        }
+      },
+      "group": {
+        "other dimension filtered remove": function() {
+          var set = [
+            {name: "alpha", quantity: 1, tags: [1, 3]},
+            {name: "bravo", quantity: 0, tags: [1, 3]},
+            {name: "charlie", quantity: 3, tags: [2]},
+            {name: "delta", quantity: 3, tags: [2, 3]},
+            {name: "echo", quantity: 2, tags: [4]},
+            {name: "foxtrot", quantity: 1, tags: []}
+          ];
+          var data = crossfilter();
+          data.tags = data.dimension(function(d) { return d.tags; }, true);
+          data.quantity = data.dimension(function(d) { return d.quantity; });
+          data.tagGroup = data.tags.group();
+          data.add(set);
+          data.quantity.filterExact(3);
+          var top2 = data.tagGroup.top(5);
+          data.remove();
+          data.quantity.filterAll();
+          assert.deepEqual(data.tagGroup.all(), [
+            {key: 1, value: 2},
+            {key: 3, value: 2},
+            {key: 4, value: 1}
+          ]);
+        },
+        "self filterExact remove": function() {
+          var set = [
+            {name: "alpha", quantity: 1, tags: [1, 3]},
+            {name: "bravo", quantity: 0, tags: [1, 3]},
+            {name: "charlie", quantity: 3, tags: [2]},
+            {name: "delta", quantity: 3, tags: [2, 3]},
+            {name: "echo", quantity: 2, tags: [4]},
+            {name: "foxtrot", quantity: 1, tags: []}
+          ];
+          var data = crossfilter();
+          data.tags = data.dimension(function(d) { return d.tags; }, true);
+          data.tagGroup = data.tags.group();
+          data.add(set);
+          data.tags.filterExact(2);
+          data.remove();
+          data.tags.filterAll();
+          assert.deepEqual(data.tagGroup.all(), [
+            {key: 1, value: 2},
+            {key: 3, value: 2},
+            {key: 4, value: 1}
+          ]);
+        },
+        "self filterFunction remove": function() {
+          var set = [
+            {name: "alpha", quantity: 1, tags: [1, 3]},
+            {name: "bravo", quantity: 0, tags: [1, 3]},
+            {name: "charlie", quantity: 3, tags: [2]},
+            {name: "delta", quantity: 3, tags: [2, 3]},
+            {name: "echo", quantity: 2, tags: [4]},
+            {name: "foxtrot", quantity: 1, tags: []}
+          ];
+          var data = crossfilter();
+          data.tags = data.dimension(function(d) { return d.tags; }, true);
+          data.tagGroup = data.tags.group();
+          data.add(set);
+          data.tags.filterFunction(function(d) { return d === 2; });
+          data.remove();
+          data.tags.filterAll();
+          assert.deepEqual(data.tagGroup.all(), [
+            {key: 1, value: 2},
+            {key: 3, value: 2},
+            {key: 4, value: 1}
+          ]);
+        },
+        "other dimension filtered then self filterFunction remove": function() {
+          var set = [
+            {name: "alpha", quantity: 1, tags: [1, 3]},
+            {name: "bravo", quantity: 0, tags: [1, 3]},
+            {name: "charlie", quantity: 3, tags: [2]},
+            {name: "delta", quantity: 3, tags: [2, 3]},
+            {name: "echo", quantity: 2, tags: [4]},
+            {name: "foxtrot", quantity: 1, tags: []}
+          ];
+          var data = crossfilter();
+          data.tags = data.dimension(function(d) { return d.tags; }, true);
+          data.quantity = data.dimension(function(d) { return d.quantity; });
+          data.tagGroup = data.tags.group();
+          data.add(set);
+          data.quantity.filterExact(3);
+          data.remove();
+          data.quantity.filterAll();
+          data.tags.filterFunction(function(d) { return d === 1; });
+          data.remove();
+          data.tags.filterAll();
+          assert.deepEqual(data.tagGroup.all(), [
+            {key: 4, value: 1}
+          ]);
+        },
+        "filter then remove to one tag with one empty": function() {
+          var set = [
+            {name: "alpha", quantity: 2, tags: [1]},
+            {name: "bravo", quantity: 1, tags: []},
+            {name: "charlie", quantity: 0, tags: [2]}
+          ];
+          var data = crossfilter();
+          data.tags = data.dimension(function(d) { return d.tags; }, true);
+          data.quantity = data.dimension(function(d) {return d.quantity; });
+          data.tagGroup = data.tags.group();
+          data.add(set);
+          data.quantity.filterExact(0);
+          data.remove();
+          data.quantity.filterAll();
+          assert.deepEqual(data.tagGroup.all(), [
+            {key: 1, value: 1}
+          ]);
+        },
+        "filter then remove empty tag to only one tag": function() {
+          var set = [
+            {name: "alpha", quantity: 2, tags: [1]},
+            {name: "bravo", quantity: 1, tags: []}
+          ];
+          var data = crossfilter();
+          data.tags = data.dimension(function(d) { return d.tags; }, true);
+          data.quantity = data.dimension(function(d) {return d.quantity; });
+          data.tagGroup = data.tags.group();
+          data.add(set);
+          data.quantity.filterExact(1);
+          data.remove();
+          data.quantity.filterAll();
+          assert.deepEqual(data.tagGroup.all(), [
+            {key: 1, value: 1}
+          ]);
+        },
+        "filter then remove one tag to only empty tag": function() {
+          var set = [
+            {name: "alpha", quantity: 2, tags: [1]},
+            {name: "bravo", quantity: 1, tags: []}
+          ];
+          var data = crossfilter();
+          data.tags = data.dimension(function(d) { return d.tags; }, true);
+          data.quantity = data.dimension(function(d) {return d.quantity; });
+          data.tagGroup = data.tags.group();
+          data.add(set);
+          data.quantity.filterExact(2);
+          data.remove();
+          data.quantity.filterAll();
+          assert.deepEqual(data.tagGroup.all(), []);
+        },
+        "remove then add one tag back": function() {
+          var firstSet = [
+            {name: "alpha", quantity: 2, tags: [1]},
+            {name: "bravo", quantity: 1, tags: []}
+          ];
+          var secondSet = [
+            {name: "alpha", quantity: 2, tags: [1]}
+          ];
+          var data = crossfilter();
+          data.tags = data.dimension(function(d) { return d.tags; }, true);
+          data.quantity = data.dimension(function(d) {return d.quantity; });
+          data.tagGroup = data.tags.group();
+          data.add(firstSet);
+          data.quantity.filterExact(2);
+          data.remove();
+          data.quantity.filterAll();
+          data.add(secondSet);
+          assert.deepEqual(data.tagGroup.all(), [
+            {key: 1, value: 1}
+          ]);
+        },
+        "remove then add empty tag back": function() {
+          var firstSet = [
+            {name: "alpha", quantity: 2, tags: [1]},
+            {name: "bravo", quantity: 1, tags: []}
+          ];
+          var secondSet = [
+            {name: "bravo", quantity: 1, tags: []}
+          ];
+          var data = crossfilter();
+          data.tags = data.dimension(function(d) { return d.tags; }, true);
+          data.quantity = data.dimension(function(d) {return d.quantity; });
+          data.tagGroup = data.tags.group();
+          data.add(firstSet);
+          data.quantity.filterExact(1);
+          data.remove();
+          data.quantity.filterAll();
+          data.add(secondSet);
+          assert.deepEqual(data.tagGroup.all(), [
+            {key: 1, value: 1}
+          ]);
+        },
+      }
+    },
     "isElementFiltered": {
       "Test if elements are filtered": function(data) {
         try {


### PR DESCRIPTION
So I went down a bit of a rabbit hole with removing data with iterable dimensions. It seems that iterable dimensions and groups were never accounted for in the removeData functions.

There were also some issues with filterFunctions after the removal of data. The length of the index was being used even though the index array is never trimmed after data had been removed. The value array is trimmed, so I replaced the references to `index.length` with `values.length`. Also, `n` (the number of records) was being used as the default upper bounds when a filterFunction was being set. This, unfortunately is not the case for iterable dimensions since the upper bound can be higher or lower than the number of records, unlike normal dimensions.

There was also a small issue with adding one value or an empty value to an empty iterable dimension. Subsequent adds to that dimension would cause issues since the cardinality would be equal to or less than one.

I also found issues with some existing unit tests. I verified my changes to them by hand, but they should definitely be double checked.