### PR TITLE
Crossfilter leaks memory when disposing groups, fixes #87

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "eslint": "2.10.2",
     "package-json-versionify": "1.0.2",
     "semver": "^5.3.0",
+    "sinon": "^4.0.2",
     "uglify-js": "2.4.0",
     "vows": "0.7.0"
   },

--- a/src/crossfilter.js
+++ b/src/crossfilter.js
@@ -1222,6 +1222,8 @@ function crossfilter() {
         if (i >= 0) indexListeners.splice(i, 1);
         i = removeDataListeners.indexOf(removeData);
         if (i >= 0) removeDataListeners.splice(i, 1);
+        i = dimensionGroups.indexOf(group);
+        if (i >= 0) dimensionGroups.splice(i, 1);
         return group;
       }
 

--- a/test/crossfilter-test.js
+++ b/test/crossfilter-test.js
@@ -1,5 +1,6 @@
 var vows = require("vows"),
     assert = require("assert"),
+    sinon = require("sinon"),
     d3 = require("d3"),
     crossfilter = require("../");
 
@@ -1047,6 +1048,20 @@ suite.addBatch({
             group.dispose();
             data.add([3, 4, 5]);
             assert.isFalse(callback);
+          },
+          "removes reference to group from dimension": function() {
+            var data = crossfilter([0, 1, 2]),
+                dimension = data.dimension(function(d) { return d; }),
+                group = dimension
+                  .group(function(d) { return d; }),
+                originalGroupDispose = group.dispose;
+
+            sinon.spy(group, "dispose")
+
+            group.dispose();
+            dimension.dispose();
+
+            assert.strictEqual(group.dispose.callCount, 1);
           }
         }
       },


### PR DESCRIPTION
This PR should fix memory leak when groups are created and disposed frequently.

Fixes #87

I haven't found any mocking/spy library in dev dependencies, so created dummy spy.

If more generic spy library is ok, we can add something like sinon. If you don't mind, I can update PR

Note that I haven't included built version of `crossfilter.js` / `crossfilter.min.js`