### PR TITLE
Broken link in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
       "url": "https://github.com/esjewett"
     }
   ],
-  "homepage": "http://crossfilter.github.com/crossfilter/",
+  "homepage": "https://crossfilter.github.io/crossfilter/",
   "main": "./index.js",
   "types": "./index.d.ts",
   "repository": {


### PR DESCRIPTION
I just found this broken link for the homepage. Annoying because it is in the metadata and displays on NPM etc.