### PR TITLE
fix: typescript definition error TS1209

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -74,7 +74,7 @@ declare namespace crossfilter {
     id(): number;
   }
 
-  export const enum EventType {
+  export enum EventType {
     DATA_ADDED = 'dataAdded',
     DATA_REMOVED = 'dataRemoved',
     FILTERED = 'filtered',


### PR DESCRIPTION
Problem:
```
Type error: Ambient const enums are not allowed when the '--isolatedModules' flag is provided.  TS1209

    75 |   }
    76 |
  > 77 |   export const enum EventType {
       |                     ^
    78 |     DATA_ADDED = 'dataAdded',
    79 |     DATA_REMOVED = 'dataRemoved',
    80 |     FILTERED = 'filtered',
```

Steps to reproduce:
```
yarn create react-app sampleProject --typescript
cd sampleProject
yarn add crossfilter2
add `import cf from "crossfilter2";` to App.tsx
yarn start
```

Reference:
Codesandbox link: https://codesandbox.io/s/w2y0xr1wrw
Now deployment: https://zeit.co/inanis/csb-w2y0xr1wrw/aqxbmozifj

***Important***: For some reason I could not reproduce the bug on Codesandbox, but during build phase in the Now deployment it happened and it also happens on my machine.

Relevante discussion: https://github.com/chalk/chalk/pull/296#issuecomment-431625641