### PR TITLE
fix #119 : Types for `reduce()` function are too restrictive

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -65,7 +65,7 @@ declare namespace crossfilter {
     hasCurrentFilter(): boolean;
     top(k: number, offset?: number): TRecord[];
     bottom(k: number, offset?: number): TRecord[];
-    group<TKey extends NaturallyOrderedValue, TGroupValue extends NaturallyOrderedValue>(
+    group<TKey extends NaturallyOrderedValue, TGroupValue>(
       groupValue?: (value: TValue) => TKey,
     ): Group<TRecord, TKey, TGroupValue>;
     groupAll<TGroupValue>(): GroupAll<TRecord, TGroupValue>;


### PR DESCRIPTION
Considering the following snippet : 

```javascript
interface Payment {
    date: string;
    quantity: number;
    total: number;
    tip: number;
    type: string;
    productIDs: String[];
}

var payments = crossfilter<Payment>([
    {date: "2011-11-14T16:17:54Z", quantity: 2, total: 190, tip: 100, type: "tab", productIDs:["001"]},
    {date: "2011-11-14T16:20:19Z", quantity: 2, total: 190, tip: 100, type: "tab", productIDs:["001", "005"]}
]);

interface Group {
    total: number;
}

var paymentsByType = payments.dimension(d => d.type);
var paymentVolumeByType = paymentsByType.group<number,  Group>().reduce(
    (p, v, nf) => {
        p.total = p.total + v.total;
        return p;
    },
    (p, v, nf) => {
        p.total = p.total - v.total;
        return p;
    },
    () => {
        return {
            total: 0
        };
    }
);
```

Without the patch, we have this TS error : 
```
[tsl] ERROR in src\app.ts(44,57)
      TS2344: Type 'Group' does not satisfy the constraint 'NaturallyOrderedValue'.
  Type 'Group' is not assignable to type 'ComparableObject'.
```

With the patch, the code compiles properly.