### PR TITLE
Add typing for arrays as returned dimension accessor type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -9,7 +9,9 @@ declare namespace crossfilter {
     valueOf(): ComparableValue;
   }
 
-  export type NaturallyOrderedValue = ComparableValue | ComparableObject;
+  export type ComparableArray = ComparableValue[] | ComparableObject[];
+
+  export type NaturallyOrderedValue = ComparableValue | ComparableObject | ComparableArray;
 
   export type Predicate<T> = (record: T) => boolean;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -9,13 +9,12 @@ declare namespace crossfilter {
     valueOf(): ComparableValue;
   }
 
-  export type ComparableArray = ComparableValue[] | ComparableObject[];
-
-  export type NaturallyOrderedValue = ComparableValue | ComparableObject | ComparableArray;
+  export type NaturallyOrderedValue = ComparableValue | ComparableObject;
 
   export type Predicate<T> = (record: T) => boolean;
 
-  export type OrderedValueSelector<TRecord, TValue extends NaturallyOrderedValue = NaturallyOrderedValue> = (
+  export type TSelectorValue = NaturallyOrderedValue | NaturallyOrderedValue[];
+  export type OrderedValueSelector<TRecord, TValue extends TSelectorValue = NaturallyOrderedValue> = (
     record: TRecord,
   ) => TValue;
 
@@ -86,7 +85,7 @@ declare namespace crossfilter {
     add(records: T[]): Crossfilter<T>;
     remove(predicate?: Predicate<T>): void;
     dimension<TValue extends NaturallyOrderedValue>(
-      selector: OrderedValueSelector<T, TValue>,
+      selector: OrderedValueSelector<T, TValue | TValue[]>,
       isArray?: boolean,
     ): Dimension<T, TValue>;
     groupAll<TGroupValue>(): GroupAll<T, TGroupValue>;


### PR DESCRIPTION
Closes #120 

This PR adds type handling for arrays as return types for dimension selectors.