### PR TITLE
Add (inefficient!) dimension.filterToggle()

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 node_modules
+package-lock.json

--- a/src/crossfilter.js
+++ b/src/crossfilter.js
@@ -557,7 +557,7 @@ function crossfilter() {
 
     // Filters this dimension by toggling exact values.
     function filterToggle(value) {
-      if (filterValue === filterToggled) {
+      if (refilterFunction === filterToggled) {
         var i = toggleValues.indexOf(value);
         if (i < 0) {
             toggleValues.push(value);
@@ -565,10 +565,12 @@ function crossfilter() {
             toggleValues.splice(i, 1);
         }
       } else {
-        filterToggled.values = toggleValues = [value];
+        toggleValues = [value];
       }
       // TODO: Rewrite without filterFunction
-      return filterFunction(filterToggled);
+      filterFunction(filterToggled);
+      filterValue = toggleValues;
+      return dimension;
     }
 
     var toggleValues;

--- a/src/crossfilter.js
+++ b/src/crossfilter.js
@@ -143,6 +143,7 @@ function crossfilter() {
     var dimension = {
       filter: filter,
       filterExact: filterExact,
+      filterToggle: filterToggle,
       filterRange: filterRange,
       filterFunction: filterFunction,
       filterAll: filterAll,
@@ -552,6 +553,27 @@ function crossfilter() {
       filterValue = undefined;
       filterValuePresent = false;
       return filterIndexBounds((refilter = xfilterFilter.filterAll)(values));
+    }
+
+    // Filters this dimension by toggling exact values.
+    function filterToggle(value) {
+      if (filterValue === filterToggled) {
+        var i = toggleValues.indexOf(value);
+        if (i < 0) {
+            toggleValues.push(value);
+        } else {
+            toggleValues.splice(i, 1);
+        }
+      } else {
+        filterToggled.values = toggleValues = [value];
+      }
+      // TODO: Rewrite without filterFunction
+      return filterFunction(filterToggled);
+    }
+
+    var toggleValues;
+    function filterToggled(d) {
+      return !toggleValues.length || toggleValues.indexOf(d) >= 0;
     }
 
     // Filters this dimension using an arbitrary function.

--- a/test/benchmark.js
+++ b/test/benchmark.js
@@ -99,6 +99,25 @@ for (var i = 0, n = 35, k = 0; i < n; ++i) {
 console.log("Filtering by amount: " + formatNumber((Date.now() - then) / k) + "ms/op.");
 amount.filterAll();
 
+// Simulate toggling by amount.
+then = Date.now();
+n = Math.sqrt(totalSize);
+var amountsToToggle = d3.range(n).map(function() {
+  return Math.floor(paymentRecords[Math.floor(Math.random() * totalSize)].amount);
+});
+for (var i = 0, k = 0; i < amountsToToggle.length; i++) {
+  amount.filterToggle(amountsToToggle[i]);
+  updateDisplay();
+}
+console.log("Toggling by amount: " + formatNumber((Date.now() - then) / k) + "ms/op.");
+
+for (var i = 0, k = 0; i < amountsToToggle.length; i++) {
+  amount.filterToggle(amountsToToggle[i]);
+  updateDisplay();
+}
+console.log("Untoggling by amount: " + formatNumber((Date.now() - then) / k) + "ms/op.");
+amount.filterAll();
+
 
 // Removal by predicate
 then = Date.now();

--- a/test/crossfilter-test.js
+++ b/test/crossfilter-test.js
@@ -570,6 +570,39 @@ suite.addBatch({
         }
       },
 
+      "filterToggle": {
+        "toggles/untoggles records that match successive values exactly": function(data) {
+          try {
+            data.tip.filterToggle(200);
+            assert.deepEqual(data.date.bottom(3), [
+              {date: "2011-11-14T16:28:54Z", quantity: 1, total: 300, tip: 200, type: "visa", tags: [2,4,5]},
+              {date: "2011-11-14T20:49:07Z", quantity: 2, total: 290, tip: 200, type: "tab", tags: [2,4,5]}
+            ]);
+
+            data.tip.filterToggle(100);
+            assert.equal(data.tip.top(Infinity).length, 22);
+            assert.deepEqual(data.date.bottom(3), [
+              {date: "2011-11-14T16:17:54Z", quantity: 2, total: 190, tip: 100, type: "tab", tags: [1,2,3]},
+              {date: "2011-11-14T16:20:19Z", quantity: 2, total: 190, tip: 100, type: "tab", tags: [1,3]},
+              {date: "2011-11-14T16:28:54Z", quantity: 1, total: 300, tip: 200, type: "visa", tags: [2,4,5]}
+            ]);
+
+            data.tip.filterToggle(200);
+            assert.equal(data.tip.top(Infinity).length, 20);
+            assert.deepEqual(data.date.bottom(3), [
+              {date: "2011-11-14T16:17:54Z", quantity: 2, total: 190, tip: 100, type: "tab", tags: [1,2,3]},
+              {date: "2011-11-14T16:20:19Z", quantity: 2, total: 190, tip: 100, type: "tab", tags: [1,3]},
+              {date: "2011-11-14T17:29:52Z", quantity: 1, total: 200, tip: 100, type: "visa", tags: [-1, 0, 'hello', 'world']}
+            ]);
+
+            data.tip.filterToggle(100);
+            assert.equal(data.tip.top(Infinity).length, 43);
+          } finally {
+            data.tip.filterAll();
+          }
+        }
+      },
+
       "filterRange": {
         "selects records greater than or equal to the inclusive lower bound": function(data) {
           try {
@@ -700,6 +733,28 @@ suite.addBatch({
             v = function (d) { return d == 1; };
             data.quantity.filterFunction(v);
             assert.strictEqual(data.quantity.currentFilter(), v);
+            assert.isTrue(data.quantity.hasCurrentFilter());
+
+            // toggle:
+
+            data.quantity.filterToggle(2);
+            assert.equal(typeof (v = data.quantity.currentFilter()), 'function');
+            assert.deepEqual(data.quantity.currentFilter().values, [2]);
+            assert.isTrue(data.quantity.hasCurrentFilter());
+
+            data.quantity.filterToggle(3);
+            assert.strictEqual(data.quantity.currentFilter(), v)
+            assert.deepEqual(data.quantity.currentFilter().values, [2, 3]);
+            assert.isTrue(data.quantity.hasCurrentFilter());
+
+            data.quantity.filterToggle(2);
+            assert.strictEqual(data.quantity.currentFilter(), v)
+            assert.deepEqual(data.quantity.currentFilter().values, [3]);
+            assert.isTrue(data.quantity.hasCurrentFilter());
+
+            data.quantity.filterToggle(3);
+            assert.strictEqual(data.quantity.currentFilter(), v)
+            assert.deepEqual(data.quantity.currentFilter().values, []);
             assert.isTrue(data.quantity.hasCurrentFilter());
 
             // no filter:

--- a/test/crossfilter-test.js
+++ b/test/crossfilter-test.js
@@ -738,23 +738,19 @@ suite.addBatch({
             // toggle:
 
             data.quantity.filterToggle(2);
-            assert.equal(typeof (v = data.quantity.currentFilter()), 'function');
-            assert.deepEqual(data.quantity.currentFilter().values, [2]);
+            assert.deepEqual(data.quantity.currentFilter(), [2]);
             assert.isTrue(data.quantity.hasCurrentFilter());
 
             data.quantity.filterToggle(3);
-            assert.strictEqual(data.quantity.currentFilter(), v)
-            assert.deepEqual(data.quantity.currentFilter().values, [2, 3]);
+            assert.deepEqual(data.quantity.currentFilter(), [2, 3]);
             assert.isTrue(data.quantity.hasCurrentFilter());
 
             data.quantity.filterToggle(2);
-            assert.strictEqual(data.quantity.currentFilter(), v)
-            assert.deepEqual(data.quantity.currentFilter().values, [3]);
+            assert.deepEqual(data.quantity.currentFilter(), [3]);
             assert.isTrue(data.quantity.hasCurrentFilter());
 
             data.quantity.filterToggle(3);
-            assert.strictEqual(data.quantity.currentFilter(), v)
-            assert.deepEqual(data.quantity.currentFilter().values, []);
+            assert.deepEqual(data.quantity.currentFilter(), []);
             assert.isTrue(data.quantity.hasCurrentFilter());
 
             // no filter:


### PR DESCRIPTION
It seems to be a relatively common use case that folks wish to filter by multiple exact values, and the answer is always to keep track of the values externally and use `dimension.filterFunction()`. It seems a common enough use case that it could come in the box, so I figured I'd start the conversation with some code:

```js
dimension.filterToggle(100); // same as filterExact(100)
dimension.filterToggle(200); // now 100 & 200
dimension.filterToggle(100); // now just 200
dimension.filterToggle(200); // all
```

More importantly, I'm pretty sure I've figured out how this could be significantly optimized with bisect. I just don't want to spend the time if you're not interested in the feature. Thoughts?

(Glad to discard either of the first two commits, just trying to be a good Git citizen.)

### Benchmark

Filtering by date: 0.21ms/op.
Filtering by day: 2.6ms/op.
Filtering by hour: 0.72ms/op.
Filtering by amount: 0.40ms/op.
Toggling by amount: 3.6ms/op.
Untoggling by amount: 7.7ms/op.
Removing 10000 records: 44ms.