### PR TITLE
Add readonly to some returned arrays in index.d.ts.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -30,7 +30,7 @@ declare namespace crossfilter {
 
   export interface Group<TRecord, TKey extends NaturallyOrderedValue, TValue> {
     top(k: number): Array<Grouping<TKey, TValue>>;
-    all(): Array<Grouping<TKey, TValue>>;
+    all(): ReadonlyArray<Grouping<TKey, TValue>>;
     reduce(
       add: (p: TValue, v: TRecord, nf: boolean) => TValue,
       remove: (p: TValue, v: TRecord, nf: boolean) => TValue,
@@ -90,7 +90,7 @@ declare namespace crossfilter {
     ): Dimension<T, TValue>;
     groupAll<TGroupValue>(): GroupAll<T, TGroupValue>;
     size(): number;
-    all(): T[];
+    all(): readonly T[];
     allFiltered(): T[];
     onChange(callback: (type: EventType) => void): () => void;
     isElementFiltered(index: number, ignoreDimensions?: number[]): boolean;


### PR DESCRIPTION
Those aren't cloned, so they can't be modified.

According to [`group.all()`'s documentation](https://github.com/crossfilter/crossfilter/wiki/API-Reference#wiki-group_all) that you can't modify the returned array. This wasn't reflected in `index.d.ts`. I assumed the same would hold for [`crossfilter.all()`](https://github.com/crossfilter/crossfilter/wiki/API-Reference#wiki-crossfilter_all).

This change might break some other projects that depend on this file, but I'm not sure how else to correct this. 