### PR TITLE
update eslint & uglify-js to mollify npm & github

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: node_js
 node_js:
-  - "5.9"
+  - "10"
 script: npm test

--- a/package.json
+++ b/package.json
@@ -45,12 +45,12 @@
   },
   "devDependencies": {
     "browserify": "^13.0.0",
-    "d3": "3.5",
-    "eslint": "2.10.2",
+    "d3": "^3.5.17",
+    "eslint": "^6.0.1",
     "package-json-versionify": "1.0.2",
-    "semver": "^5.3.0",
+    "semver": "^5.7.0",
     "sinon": "^4.0.2",
-    "uglify-js": "2.4.0",
+    "uglify-js": "^3.6.0",
     "vows": "0.7.0"
   },
   "scripts": {


### PR DESCRIPTION
although vulnerabilities in devDependencies are not a threat, npm and github
will complain about them. everything seems to work with these updates.

@esjewett, I think it's pretty low-risk to update these two - would be nice to get these into the next release whenever you have time for it.