### PR TITLE
restored typed arrays that were disabled in 70fb3dca54 / db6ff2d1f8a

### DIFF
--- a/src/array.js
+++ b/src/array.js
@@ -1,16 +1,21 @@
+var crossfilter_array8 = crossfilter_arrayUntyped,
+    crossfilter_array16 = crossfilter_arrayUntyped,
+    crossfilter_array32 = crossfilter_arrayUntyped,
+    crossfilter_arrayLengthen = crossfilter_arrayLengthenUntyped,
+    crossfilter_arrayWiden = crossfilter_arrayWidenUntyped;
 if (typeof Uint8Array !== "undefined") {
-  var crossfilter_array8 = function(n) { return new Uint8Array(n); };
-  var crossfilter_array16 = function(n) { return new Uint16Array(n); };
-  var crossfilter_array32 = function(n) { return new Uint32Array(n); };
+  crossfilter_array8 = function(n) { return new Uint8Array(n); };
+  crossfilter_array16 = function(n) { return new Uint16Array(n); };
+  crossfilter_array32 = function(n) { return new Uint32Array(n); };
 
-  var crossfilter_arrayLengthen = function(array, length) {
+  crossfilter_arrayLengthen = function(array, length) {
     if (array.length >= length) return array;
     var copy = new array.constructor(length);
     copy.set(array);
     return copy;
   };
 
-  var crossfilter_arrayWiden = function(array, width) {
+  crossfilter_arrayWiden = function(array, width) {
     var copy;
     switch (width) {
       case 16: copy = crossfilter_array16(array.length); break;
@@ -177,10 +182,10 @@ crossfilter_bitarray.prototype.onlyExcept = function(n, offset, zero, onlyOffset
 };
 
 module.exports = {
-  array8: crossfilter_arrayUntyped,
-  array16: crossfilter_arrayUntyped,
-  array32: crossfilter_arrayUntyped,
-  arrayLengthen: crossfilter_arrayLengthenUntyped,
-  arrayWiden: crossfilter_arrayWidenUntyped,
+  array8: crossfilter_array8,
+  array16: crossfilter_array16,
+  array32: crossfilter_array32,
+  arrayLengthen: crossfilter_arrayLengthen,
+  arrayWiden: crossfilter_arrayWiden,
   bitarray: crossfilter_bitarray
 };

--- a/src/crossfilter.js
+++ b/src/crossfilter.js
@@ -402,7 +402,7 @@ function crossfilter() {
             i1++;
           }
         }
-        iterablesIndexCount.length = i1;
+        iterablesIndexCount = iterablesIndexCount.slice(0, i1);
       }
       // Rewrite our index, overwriting removed values
       var n0 = values.length;
@@ -418,7 +418,7 @@ function crossfilter() {
         }
       }
       values.length = j;
-      if (iterable) iterablesIndexFilterStatus.length = j;
+      if (iterable) iterablesIndexFilterStatus = iterablesIndexFilterStatus.slice(0, j);
       while (j < n0) index[j++] = 0;
 
       // Bisect again to recompute lo0 and hi0.

--- a/src/crossfilter.js
+++ b/src/crossfilter.js
@@ -74,7 +74,7 @@ function crossfilter() {
   // removes all records matching the predicate (ignoring filters).
   function removeData(predicate) {
     var // Mapping from old record indexes to new indexes (after records removed)
-        newIndex = crossfilter_index(n, n),
+        newIndex = new Array(n),
         removed = [],
         usePred = typeof predicate === 'function',
         shouldRemove = function (i) {


### PR DESCRIPTION
I am very surprised that going back to typed arrays, #134, breaks 17 tests.

I'd like to see this functionality restored in 1.4.8. Even if it doesn't help performance on Chrome, it is likely to help performance on other browsers.

But why does this break anything? Anyone have an idea? I keep staring at this thinking I must have made a typo.