### PR TITLE
Change readonly syntax array for 1.4.8

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -90,7 +90,7 @@ declare namespace crossfilter {
     ): Dimension<T, TValue>;
     groupAll<TGroupValue>(): GroupAll<T, TGroupValue>;
     size(): number;
-    all(): readonly T[];
+    all(): ReadonlyArray<T>;
     allFiltered(): T[];
     onChange(callback: (type: EventType) => void): () => void;
     isElementFiltered(index: number, ignoreDimensions?: number[]): boolean;


### PR DESCRIPTION
Maybe this solves #147.  
I haven't installed Karma currently, so can't test it. 

There is no special 1.4 branch currently. The export default problem in #147 might be related to the ES6 module rewrite, so maybe that should be in a separate pull request. 