### PR TITLE
Add TypeScript types to installation steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ This package can be found under the name `crossfilter2` in npm:
 
      npm install crossfilter2
      
+(optional) if you use TypeScript:
+     
+     npm install @types/crossfilter --save-dev
+     
 ## Development
 
 Install dependencies:


### PR DESCRIPTION
I was confused because npm does not contain an `@types/crossfilter2` package. However, I expect the types to be used are https://www.npmjs.com/package/@types/crossfilter

I hope adding an explicit instruction step avoids similar confusion for other users.