### PR TITLE
add test to fix issue #158

### DIFF
--- a/src/array.js
+++ b/src/array.js
@@ -173,7 +173,7 @@ bitarray.prototype.onlyExcept = function(n, offset, zero, onlyOffset, onlyOne) {
   for (i = 0, len = this.subarrays; i < len; ++i) {
     mask = this[i][n];
     if (i === offset)
-      mask &= zero;
+      mask = (mask & zero) >>> 0;
     if (mask != (i === onlyOffset ? onlyOne : 0)) {
       return false;
     }

--- a/test/crossfilter-test.js
+++ b/test/crossfilter-test.js
@@ -3520,7 +3520,32 @@ suite.addBatch({
         }
       },
     },
+    "filter the 32nd dimension": function() {
+      var dataSet = [];
 
+      var itemBuilder = (fieldCount, value) => {
+        var item = {};
+        for (var i = 0; i < fieldCount; i++) {
+          item['f' + (i + 1)] = value;
+        }
+        return item;
+      }
+
+      dataSet.push(itemBuilder(34, 'a'));
+      dataSet.push(itemBuilder(34, 'b'));
+      var data = crossfilter(dataSet);
+
+      var dimensions = Object.keys(dataSet[0]).map(key => data.dimension(d => d[key]));
+      var groups = dimensions.map(d => d.group());
+      dimensions[31].filterExact('a');
+      // correct group value
+      var correctGroupValue = groups.map(g => g.all()[1].value);
+
+      dimensions[31].filter(null);
+      dimensions[31].filterExact('a');
+
+      assert.deepEqual(groups.map(g => g.all()[1].value), correctGroupValue);
+    },
   }
 });
 

--- a/test/crossfilter-test.js
+++ b/test/crossfilter-test.js
@@ -3539,7 +3539,7 @@ suite.addBatch({
       var groups = dimensions.map(d => d.group());
       dimensions[31].filterExact('a');
       // correct group value
-      var correctGroupValue = groups.map(g => g.all()[1].value);
+      const correctGroupValue = groups.map(g => g.all()[1].value);
 
       dimensions[31].filter(null);
       dimensions[31].filterExact('a');

--- a/test/crossfilter-test.js
+++ b/test/crossfilter-test.js
@@ -3539,7 +3539,8 @@ suite.addBatch({
       var groups = dimensions.map(d => d.group());
       dimensions[31].filterExact('a');
       // correct group value
-      const correctGroupValue = groups.map(g => g.all()[1].value);
+      const correctGroupValue = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0];
+      assert.deepEqual(groups.map(g => g.all()[1].value), correctGroupValue);
 
       dimensions[31].filter(null);
       dimensions[31].filterExact('a');


### PR DESCRIPTION
Hi @gordonwoodhull!

I add the test to fix issue  #158  that all groups below 32 are unfiltered after filtering the 32nd dimension.

Is this test okay， or need to be modified? 